### PR TITLE
Add minimal ansible.cfg file

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+collections_paths = ./.ansible/collections
+nocows = True
+retry_files_enabled = False
+roles_path = ./.ansible/roles

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,7 +1,7 @@
 ---
 dependency:
   name: galaxy
-  enabled: False
+  enabled: false
 driver:
   name: docker
 platforms:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,7 +1,7 @@
 ---
+prerun: false
 dependency:
   name: galaxy
-  enabled: false
 driver:
   name: docker
 platforms:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,6 +1,8 @@
 ---
 dependency:
   name: galaxy
+  options:
+    collections-path: .ansible/collections
 driver:
   name: docker
 platforms:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,8 +1,7 @@
 ---
 dependency:
   name: galaxy
-  options:
-    collections-path: .ansible/collections
+  enabled: False
 driver:
   name: docker
 platforms:


### PR DESCRIPTION
This prevents errors on our CI server by not checking out collections or roles in shared locations.