### PR TITLE
Force role installation

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,6 +1,8 @@
 ---
 dependency:
   name: galaxy
+  options:
+    force: true
 driver:
   name: docker
 platforms:


### PR DESCRIPTION
This resolves an issue where Molecule would sometimes fail to install role dependencies